### PR TITLE
Remove duplicate 'posts_per_archive_page' rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ $args = array(
     //http://codex.wordpress.org/Class_Reference/WP_Query#Pagination_Parameters
     'posts_per_page' => 10, // (int) - number of post to show per page (available with Version 2.1). Use 'posts_per_page' => -1 to show all posts.
                             // Note: if the query is in a feed, wordpress overwrites this parameter with the stored 'posts_per_rss' option. Treimpose the limit, try using the 'post_limits' filter, or filter 'pre_option_posts_per_rss' and return -1
-    'posts_per_archive_page' => 10, // (int) - number of posts to show per page - on archive pages only. Over-rides showposts anposts_per_page on pages where is_archive() or is_search() would be true
     'nopaging' => false, // (bool) - show all posts or use pagination. Default value is 'false', use paging.
     'paged' => get_query_var('paged'), // (int) - number of page. Show the posts that would normally show up just on page X when usinthe "Older Entries" link.
                                        // NOTE: Use get_query_var('page'); if you want your query to work in a Page template that you've set as your static front page. The query variable 'page' holds the pagenumber for a single paginated Post or Page that includes the <!--nextpage--> Quicktag in the post content.


### PR DESCRIPTION
## Description
- Remove duplicate rule, keeping the one with the most up-to-date description.

## Related Documentation
- See pagination parameters here: https://codex.wordpress.org/Class_Reference/WP_Query.