### PR TITLE
Replace Codex links with DevHub links

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,21 +32,21 @@
 * WordPress Query Comprehensive Reference
 * Compiled by luetkemj - luetkemj.github.io
 *
-* CODEX: http://codex.wordpress.org/Class_Reference/WP_Query#Parameters
+* Dev Hub: https://developer.wordpress.org/reference/classes/wp_query/#parameters
 * Source: https://core.trac.wordpress.org/browser/tags/4.9.4/src/wp-includes/query.php
 */</span>
 
 <span class="nv">$args</span> <span class="o">=</span> <span class="k">array</span><span class="p">(</span>
 
 <span class="c1">// Author Parameters - Show posts associated with certain author.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Author_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#author-parameters
 </span>  <span class="s1">'author'</span> <span class="o">=&gt;</span> <span class="s1">'1,2,3,'</span><span class="p">,</span> <span class="c1">// (int | string) -  use author id or comma-separated list of IDs [use minus (-) to exclude authors by ID ex. 'author' =&gt; '-1,-2,-3,']
 </span>  <span class="s1">'author_name'</span> <span class="o">=&gt;</span> <span class="s1">'luetkemj'</span><span class="p">,</span> <span class="c1">// (string) - use 'user_nicename' (NOT name)
 </span>  <span class="s1">'author__in'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">6</span> <span class="p">),</span> <span class="c1">// (array) - use author id (available with Version 3.7).
 </span>  <span class="s1">'author__not_in'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">6</span> <span class="p">),</span> <span class="c1">// (array)' - use author id (available with Version 3.7).
 </span>
 <span class="c1">// Category Parameters - Show posts associated with certain categories.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Category_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#category-parameters
 </span>  <span class="s1">'cat'</span> <span class="o">=&gt;</span> <span class="mi">5</span><span class="p">,</span> <span class="c1">// (int) - Display posts that have this category (and any children of that category), using category id.
 </span>  <span class="s1">'cat'</span> <span class="o">=&gt;</span> <span class="s1">'-12,-34,-56'</span> <span class="c1">// Display all posts except those from a category by prefixing its id with a '-' (minus) sign.
 </span>  <span class="s1">'category_name'</span> <span class="o">=&gt;</span> <span class="s1">'staff, news'</span><span class="p">,</span> <span class="c1">// (string) - Display posts that have these categories (and any children of that category), using category slug.
@@ -56,7 +56,7 @@
 </span>  <span class="s1">'category__not_in'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">6</span> <span class="p">),</span> <span class="c1">// (array) - Display posts that DO NOT HAVE these categories (not children of that category), using category id.
 </span>
 <span class="c1">// Tag Parameters - Show posts associated with certain tags.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Tag_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#tag-parameters
 </span>  <span class="s1">'tag'</span> <span class="o">=&gt;</span> <span class="s1">'cooking'</span><span class="p">,</span> <span class="c1">// (string) - use tag slug.
 </span>  <span class="s1">'tag_id'</span> <span class="o">=&gt;</span> <span class="mi">5</span><span class="p">,</span> <span class="c1">// (int) - use tag id.
 </span>  <span class="s1">'tag__and'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">6</span><span class="p">),</span> <span class="c1">// (array) - use tag ids.
@@ -66,7 +66,7 @@
 </span>  <span class="s1">'tag_slug__in'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="s1">'red'</span><span class="p">,</span> <span class="s1">'blue'</span><span class="p">),</span> <span class="c1">// (array) - use tag slugs.
 </span>
 <span class="c1">// Taxonomy Parameters - Show posts associated with certain taxonomy.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#taxonomy-parameters
 // Important Note: tax_query takes an array of tax query arguments arrays (it takes an array of arrays)
 // This construct allows you to query multiple taxonomies by using the relation parameter in the first (outer) array to describe the boolean relationship between the taxonomy queries.
 </span>  <span class="s1">'tax_query'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="c1">// (array) - use taxonomy parameters (available with Version 3.1).
@@ -88,7 +88,7 @@
   <span class="p">),</span>
 
 <span class="c1">// Post &amp; Page Parameters - Display content based on post and page parameters.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Post_.26_Page_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#post-page-parameters
 </span>  <span class="s1">'p'</span> <span class="o">=&gt;</span> <span class="mi">1</span><span class="p">,</span> <span class="c1">// (int) - use post id.
 </span>  <span class="s1">'name'</span> <span class="o">=&gt;</span> <span class="s1">'hello-world'</span><span class="p">,</span> <span class="c1">// (string) - use post slug.
 </span>  <span class="s1">'title'</span> <span class="o">=&gt;</span> <span class="s1">'Hello World'</span> <span class="c1">// (string) - use post title (available with Version 4.4)
@@ -104,7 +104,7 @@
 </span>  <span class="c1">// NOTE: you cannot combine 'post__in' and 'post__not_in' in the same query
 </span>
 <span class="c1">// Password Parameters - Show content based on post and page parameters. Remember that default post_type is only set to display posts but not pages.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Password_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#password-parameters
 </span>  <span class="s1">'has_password'</span> <span class="o">=&gt;</span> <span class="kc">true</span><span class="p">,</span> <span class="c1">// (bool) - available with Version 3.9
 </span>                          <span class="c1">// true for posts with passwords;
 </span>                          <span class="c1">// false for posts without passwords;
@@ -112,7 +112,7 @@
 </span>  <span class="s1">'post_password'</span> <span class="o">=&gt;</span> <span class="s1">'multi-pass'</span><span class="p">,</span> <span class="c1">// (string) - show posts with a particular password (available with Version 3.9)
 </span>
 <span class="c1">// Post Type Parameters - Show posts associated with certain type or status.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Type_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#post-type-parameters
 </span>  <span class="s1">'post_type'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="c1">// (string / array) - use post types. Retrieves posts by Post Types, default value is 'post';
 </span>    <span class="s1">'post'</span><span class="p">,</span> <span class="c1">// - a post.
 </span>    <span class="s1">'page'</span><span class="p">,</span> <span class="c1">// - a page.
@@ -125,7 +125,7 @@
 </span>  <span class="s1">'post_type'</span> <span class="o">=&gt;</span> <span class="s1">'any'</span><span class="p">,</span> <span class="c1">// - retrieves any type except revisions and types with 'exclude_from_search' set to true.
 </span>
 <span class="c1">// Post Status Parameters - Show posts associated with certain type or status.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Status_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#status-parameters
 </span>    <span class="s1">'post_status'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="c1">// (string | array) - use post status. Retrieves posts by Post Status, default value i'publish'.
 </span>      <span class="s1">'publish'</span><span class="p">,</span> <span class="c1">// - a published post or page.
 </span>      <span class="s1">'pending'</span><span class="p">,</span> <span class="c1">// - post is pending review.
@@ -141,7 +141,7 @@
 </span>
 
 <span class="c1">// Comment Paremters - @since Version 4.9 Introduced the `$comment_count` parameter.
-// https://codex.wordpress.org/Class_Reference/WP_Query#Comment_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#comment-parameters
 </span>    <span class="s1">'comment_count'</span> <span class="o">=&gt;</span> <span class="mi">10</span> <span class="c1">// (int | array) The amount of comments your CPT has to have ( Search operator will do a '=' operation )
 </span>    <span class="s1">'comment_count'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span>
       <span class="s1">'value'</span> <span class="o">=&gt;</span> <span class="mi">10</span> <span class="c1">// (int) - The amount of comments your CPT has to have when comparing
@@ -149,7 +149,7 @@
 </span>    <span class="p">)</span>
 
 <span class="c1">// Pagination Parameters
-</span>    <span class="c1">//http://codex.wordpress.org/Class_Reference/WP_Query#Pagination_Parameters
+</span>    <span class="c1">//https://developer.wordpress.org/reference/classes/wp_query/#pagination-parameters
 </span>    <span class="s1">'posts_per_page'</span> <span class="o">=&gt;</span> <span class="mi">10</span><span class="p">,</span> <span class="c1">// (int) - number of post to show per page (available with Version 2.1). Use 'posts_per_page' =&gt; -1 to show all posts.
 </span>                            <span class="c1">// Note: if the query is in a feed, wordpress overwrites this parameter with the stored 'posts_per_rss' option. Treimpose the limit, try using the 'post_limits' filter, or filter 'pre_option_posts_per_rss' and return -1
 </span>    <span class="s1">'nopaging'</span> <span class="o">=&gt;</span> <span class="kc">false</span><span class="p">,</span> <span class="c1">// (bool) - show all posts or use pagination. Default value is 'false', use paging.
@@ -162,14 +162,14 @@
 </span>                   <span class="c1">// The 'offset' parameter is ignored when 'posts_per_page'=&gt;-1 (show all posts) is used.
 </span>    <span class="s1">'paged'</span> <span class="o">=&gt;</span> <span class="nx">get_query_var</span><span class="p">(</span><span class="s1">'paged'</span><span class="p">),</span> <span class="c1">// (int) - number of page. Show the posts that would normally show up just on page X when usinthe "Older Entries" link.
 </span>                                       <span class="c1">// NOTE: This whole paging thing gets tricky. Some links to help you out:
-</span>                                       <span class="c1">// http://codex.wordpress.org/Function_Reference/next_posts_link#Usage_when_querying_the_loop_with_WP_Query
+</span>                                       <span class="c1">// https://developer.wordpress.org/reference/functions/next_posts_link/
 </span>                                       <span class="c1">// http://codex.wordpress.org/Pagination#Troubleshooting_Broken_Pagination
 </span>    <span class="s1">'page'</span> <span class="o">=&gt;</span> <span class="nx">get_query_var</span><span class="p">(</span><span class="s1">'page'</span><span class="p">),</span> <span class="c1">// (int) - number of page for a static front page. Show the posts that would normally show up just on page X of a Static Front Page.
 </span>                                     <span class="c1">// NOTE: The query variable 'page' holds the pagenumber for a single paginated Post or Page that includes the &lt;!--nextpage--&gt; Quicktag in the post content.
 </span>    <span class="s1">'ignore_sticky_posts'</span> <span class="o">=&gt;</span> <span class="kc">false</span><span class="p">,</span> <span class="c1">// (boolean) - ignore sticky posts or not (available with Version 3.1, replaced caller_get_posts parameter). Default value is 0 - don't ignore sticky posts. Note: ignore/exclude sticky posts being included at the beginning of posts returned, but the sticky post will still be returned in the natural order of that list of posts returned.
 </span>
 <span class="c1">// Order &amp; Orderby Parameters - Sort retrieved posts.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters
 </span>    <span class="s1">'order'</span> <span class="o">=&gt;</span> <span class="s1">'DESC'</span><span class="p">,</span> <span class="c1">// (string) - Designates the ascending or descending order of the 'orderby' parameter. Default to 'DESC'.
 </span>                       <span class="c1">//Possible Values:
 </span>                       <span class="c1">//'ASC' - ascending order from lowest to highest values (1, 2, 3; a, b, c).
@@ -197,7 +197,7 @@
 </span>                         <span class="c1">// 'post_parent__in' - Preserve post parent order given in the 'post_parent__in' array (available since Version 4.6). Note - the value of the order parameter does not change the resulting sort order.
 </span>
 <span class="c1">// Date Parameters - Show posts associated with a certain time and date period.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Date_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
 </span>    <span class="s1">'year'</span> <span class="o">=&gt;</span> <span class="mi">2014</span><span class="p">,</span> <span class="c1">// (int) - 4 digit year (e.g. 2011).
 </span>    <span class="s1">'monthnum'</span> <span class="o">=&gt;</span> <span class="mi">4</span><span class="p">,</span> <span class="c1">// (int) - Month number (from 1 to 12).
 </span>    <span class="s1">'w'</span> <span class="o">=&gt;</span>  <span class="mi">25</span><span class="p">,</span> <span class="c1">// (int) - Week of the year (from 0 to 53). Uses the MySQL WEEK command. The mode is dependenon the "start_of_week" option.
@@ -207,7 +207,7 @@
 </span>    <span class="s1">'second'</span> <span class="o">=&gt;</span> <span class="mi">30</span><span class="p">,</span> <span class="c1">// (int) - Second (0 to 60).
 </span>    <span class="s1">'m'</span> <span class="o">=&gt;</span> <span class="mi">201404</span><span class="p">,</span> <span class="c1">// (int) - YearMonth (For e.g.: 201307).
 </span>    <span class="s1">'date_query'</span> <span class="o">=&gt;</span> <span class="k">array</span><span class="p">(</span> <span class="c1">// (array) - Date parameters (available with Version 3.7).
-</span>                           <span class="c1">// these are super powerful. check out the codex for more comprehensive code examples http://codex.wordpress.org/Class_Reference/WP_Query#Date_Parameters
+</span>                           <span class="c1">// these are super powerful. check out the Dev Hub for more comprehensive code examples https://developer.wordpress.org/reference/classes/wp_query/#date-parameters
 </span>      <span class="k">array</span><span class="p">(</span>
         <span class="s1">'year'</span> <span class="o">=&gt;</span> <span class="mi">2014</span><span class="p">,</span> <span class="c1">// (int) - 4 digit year (e.g. 2011).
 </span>        <span class="s1">'month'</span> <span class="o">=&gt;</span> <span class="mi">4</span><span class="p">,</span> <span class="c1">// (int) - Month number (from 1 to 12).
@@ -230,7 +230,7 @@
     <span class="p">),</span>
 
 <span class="c1">// Custom Field Parameters - Show posts associated with a certain custom field.
-// http://codex.wordpress.org/Class_Reference/WP_Query#Custom_Field_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#custom-field-post-meta-parameters
 </span>    <span class="s1">'meta_key'</span> <span class="o">=&gt;</span> <span class="s1">'key'</span><span class="p">,</span> <span class="c1">// (string) - Custom field key.
 </span>    <span class="s1">'meta_value'</span> <span class="o">=&gt;</span> <span class="s1">'value'</span><span class="p">,</span> <span class="c1">// (string) - Custom field value.
 </span>    <span class="s1">'meta_value_num'</span> <span class="o">=&gt;</span> <span class="mi">10</span><span class="p">,</span> <span class="c1">// (number) - Custom field value.
@@ -239,7 +239,7 @@
 </span>      <span class="s1">'relation'</span> <span class="o">=&gt;</span> <span class="s1">'AND'</span><span class="p">,</span> <span class="c1">// (string) - Possible values are 'AND', 'OR'. The logical relationship between each inner meta_query array when there is more than one. Do not use with a single inner meta_query array.
 </span>       <span class="k">array</span><span class="p">(</span>
          <span class="s1">'key'</span> <span class="o">=&gt;</span> <span class="s1">'color'</span><span class="p">,</span> <span class="c1">// (string) - Custom field key.
-</span>         <span class="s1">'value'</span> <span class="o">=&gt;</span> <span class="s1">'blue'</span><span class="p">,</span> <span class="c1">// (string/array) - Custom field value (Note: Array support is limited to a compare value of 'IN', 'NOT IN', 'BETWEEN', or 'NOT BETWEEN') Using WP &lt; 3.9? Check out this page for details: http://codex.wordpress.org/Class_Reference/WP_Query#Custom_Field_Parameters
+</span>         <span class="s1">'value'</span> <span class="o">=&gt;</span> <span class="s1">'blue'</span><span class="p">,</span> <span class="c1">// (string/array) - Custom field value (Note: Array support is limited to a compare value of 'IN', 'NOT IN', 'BETWEEN', or 'NOT BETWEEN') Using WP &lt; 3.9? Check out this page for details: https://developer.wordpress.org/reference/classes/wp_query/#custom-field-post-meta-parameters
 </span>         <span class="s1">'type'</span> <span class="o">=&gt;</span> <span class="s1">'CHAR'</span><span class="p">,</span> <span class="c1">// (string) - Custom field type. Possible values are 'NUMERIC', 'BINARY', 'CHAR', 'DATE', 'DATETIME', 'DECIMAL', 'SIGNED', 'TIME', 'UNSIGNED'. Default value is 'CHAR'. The 'type' DATE works with the 'compare' value BETWEEN only if the date is stored at the format YYYYMMDD and tested with this format.
 </span>                           <span class="c1">//NOTE: The 'type' DATE works with the 'compare' value BETWEEN only if the date is stored at the format YYYYMMDD and tested with this format.
 </span>         <span class="s1">'compare'</span> <span class="o">=&gt;</span> <span class="s1">'='</span><span class="p">,</span> <span class="c1">// (string) - Operator to test. Possible values are '=', '!=', '&gt;', '&gt;=', '&lt;', '&lt;=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'EXISTS' (only in WP &gt;= 3.5), and 'NOT EXISTS' (also only in WP &gt;= 3.5). Default value is '='.
@@ -252,16 +252,16 @@
     <span class="p">),</span>
 
 <span class="c1">// Permission Parameters - Display published posts, as well as private posts, if the user has the appropriate capability:
-// http://codex.wordpress.org/Class_Reference/WP_Query#Permission_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#permission-parameters
 </span>    <span class="s1">'perm'</span> <span class="o">=&gt;</span> <span class="s1">'readable'</span><span class="p">,</span> <span class="c1">// (string) Possible values are 'readable', 'editable'
 </span>
 <span class="c1">// Mime Type Parameters - Used with the attachments post type.
-// https://codex.wordpress.org/Class_Reference/WP_Query#Mime_Type_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#mime-type-parameters
 </span>    <span class="s1">'post_mime_type'</span> <span class="o">=&gt;</span> <span class="s1">'image/gif'</span><span class="p">,</span> <span class="c1">// (string/array) - Allowed mime types.
 </span>
 
 <span class="c1">// Caching Parameters
-// http://codex.wordpress.org/Class_Reference/WP_Query#Caching_Parameters
+// https://developer.wordpress.org/reference/classes/wp_query/#caching-parameters
 // NOTE Caching is a good thing. Setting these to false is generally not advised.
 </span>    <span class="s1">'cache_results'</span> <span class="o">=&gt;</span> <span class="kc">true</span><span class="p">,</span> <span class="c1">// (bool) Default is true - Post information cache.
 </span>    <span class="s1">'update_post_term_cache'</span> <span class="o">=&gt;</span> <span class="kc">true</span><span class="p">,</span> <span class="c1">// (bool) Default is true - Post meta information cache.
@@ -270,13 +270,13 @@
 </span>
 
 <span class="c1">// Search Parameter
-// http://codex.wordpress.org/Class_Reference/WP_Query#Search_Parameter
+// https://developer.wordpress.org/reference/classes/wp_query/#search-parameters
 </span>    <span class="s1">'s'</span> <span class="o">=&gt;</span> <span class="nv">$s</span><span class="p">,</span> <span class="c1">// (string) - Passes along the query string variable from a search. For example usage see: http://www.wprecipes.com/how-to-display-the-number-of-results-in-wordpress-search
 </span>    <span class="s1">'exact'</span> <span class="o">=&gt;</span> <span class="kc">true</span><span class="p">,</span> <span class="c1">// (bool) - flag to make it only match whole titles/posts - Default value is false. For more information see: https://gist.github.com/2023628#gistcomment-285118
 </span>    <span class="s1">'sentence'</span> <span class="o">=&gt;</span> <span class="kc">true</span><span class="p">,</span> <span class="c1">// (bool) - flag to make it do a phrase search - Default value is false. For more information see: https://gist.github.com/2023628#gistcomment-285118
 </span>
 <span class="c1">// Post Field Parameters
-// For more info see: http://codex.wordpress.org/Class_Reference/WP_Query#Return_Fields_Parameter
+// For more info see: https://developer.wordpress.org/reference/classes/wp_query/#return-fields-parameter
 // also https://gist.github.com/luetkemj/2023628/#comment-1003542
 </span>    <span class="s1">'fields'</span> <span class="o">=&gt;</span> <span class="s1">'ids'</span><span class="p">,</span> <span class="c1">// (string) - Which fields to return. All fields are returned by default.
 </span>                       <span class="c1">// Possible values:
@@ -285,7 +285,7 @@
 </span>                       <span class="c1">// Passing anything else will return all fields (default) - an array of post objects.
 </span>
 <span class="c1">// Filters
-// For more information on available Filters see: http://codex.wordpress.org/Class_Reference/WP_Query#Filters
+// For more information on available Filters see: https://codex.wordpress.org/Plugin_API/Filter_Reference#WP_Query_Filters
 </span>
 <span class="p">);</span>
 


### PR DESCRIPTION
Since Codex migrated to DevHub, most of links in the document are outdated.

This PR replace Codex links with DevHub links, except for : 
- http://codex.wordpress.org/Making_Custom_Queries_using_Offset_and_Pagination (no DevHub equivalence found)
- http://codex.wordpress.org/Pagination#Troubleshooting_Broken_Pagination (no DevHub equivalence found)
- http://codex.wordpress.org/Class_Reference/WP_Query#Filters replaced with another Codex link : https://codex.wordpress.org/Plugin_API/Filter_Reference#WP_Query_Filters

Related to this issue : https://github.com/luetkemj/wp-query-ref/issues/8